### PR TITLE
Text and URL change for submitting vulnerabilities. 

### DIFF
--- a/src/content/docs/security/security-privacy/information-security/report-security-vulnerabilities-hackerone.mdx
+++ b/src/content/docs/security/security-privacy/information-security/report-security-vulnerabilities-hackerone.mdx
@@ -1,15 +1,15 @@
 ---
-title: Report security vulnerabilities via HackerOne
+title: Report security vulnerabilities to New Relic
 tags:
   - Security
   - Security and Privacy
   - Information security
-metaDescription: New Relic has partnered with HackerOne to make it as easy as possible for researchers to report security vulnerabilities to us.
+metaDescription: New Relic has partnered with a third party to make it as easy as possible for researchers to report security vulnerabilities to us.
 redirects:
   - /docs/security/new-relic-security/data-privacy/reporting-security-vulnerabilities
   - /docs/security/new-relic-security/data-privacy/report-security-vulnerabilities
-  - /docs/security/new-relic-security/data-privacy/report-security-vulnerabilities-hackerone
-  - /docs/security/new-relic-security/information-security/report-security-vulnerabilities-hackerone
+  - /docs/security/security-privacy/information-security/report-security-vulnerabilities
+
 ---
 
 New Relic is committed to the security of our customers and your data. We believe that engaging with security researchers through our coordinated disclosure program is an important measure to achieve our security goals.
@@ -18,11 +18,13 @@ If you believe you have found a security vulnerability in one of our products or
 
 ## Coordinated disclosure program [#coordinated_disclosure_program]
 
-New Relic has partnered with HackerOne to make it as easy as possible for researchers to report security vulnerabilities to us. In recognition of the effort involved in finding these issues, we may provide bounties for eligible reports. For full details of our policies and to see previously disclosed reports, go to the [coordinated disclosure page on HackerOne](https://hackerone.com/newrelic) for New Relic.
+Please not that this program is currently in transition and not available during this transistion. We are still able to accept security reports via security@newrelic.com.
+
+New Relic has partnered with BugCrowd to make it as easy as possible for researchers to report security vulnerabilities to us. In recognition of the effort involved in finding these issues, we may provide bounties for eligible reports. For full details of our policies and to see previously disclosed reports, go to the [coordinated disclosure page on HackerOne](https://hackerone.com/newrelic) for New Relic.
 
 To participate in the coordinated disclosure program:
 
-1. Ensure that you're familiar with [our policies with HackerOne](https://hackerone.com/newrelic) before initiating any security testing.
+1. Ensure that you're familiar with [our policies with BugCrowd] (URL currently unavailable) before initiating any security testing.
 2. Only test against accounts you control.
 
 ## Customer security issues [#customer-issues]


### PR DESCRIPTION
We are moving from HackerOne to BugCrowd but the program is temporarily unavailable. I will make another edit when there is a URL to submit issues.